### PR TITLE
Add daily log rotation using winston-daily-rotate-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 image-instruction.txt
 *.log
+*.bat

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM node:16
 
 RUN adduser node root
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install tzdata
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install tzdata -y
 
 RUN ln -sf /usr/share/zoneinfo/Asia/Jakarta /etc/localtime
 RUN echo "Asia/Jakarta" > /etc/timezone
 
 RUN dpkg-reconfigure --frontend noninteractive tzdata
+
 
 WORKDIR /app
 
@@ -31,5 +33,6 @@ RUN if [ "$ENVIRONMENT" != "PROD" ]; then mkdir /jumphost-logs && chgrp -R 0 /ju
 EXPOSE 8080
 USER 1000
 
-CMD ["sh", "-c", "npm run prod | tee /jumphost-logs/jumphost.log"]
+CMD [ "npm", "run", "prod" ]
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN chown -R node:root /app
 RUN mkdir /.npm
 RUN chgrp -R 0 /.npm && chmod -R g=u /.npm
 
-RUN mkdir /jumphost-logs
-RUN chgrp -R 0 /jumphost-logs && chmod -R g=u /jumphost-logs
+ARG ENVIRONMENT
+ENV ENVIRONMENT=${ENVIRONMENT}
+
+RUN if [ "$ENVIRONMENT" != "PROD" ]; then mkdir /jumphost-logs && chgrp -R 0 /jumphost-logs && chmod -R g=u /jumphost-logs; fi
 
 EXPOSE 8080
 USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@ FROM node:16
 
 RUN adduser node root
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install tzdata
+
+RUN ln -sf /usr/share/zoneinfo/Asia/Jakarta /etc/localtime
+RUN echo "Asia/Jakarta" > /etc/timezone
+
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
 WORKDIR /app
 
 COPY package*.json ./
@@ -14,11 +21,13 @@ RUN chmod -R 775 /app
 RUN chown -R node:root /app
 
 RUN mkdir /.npm
-
 RUN chgrp -R 0 /.npm && chmod -R g=u /.npm
 
-EXPOSE 8080
+RUN mkdir /jumphost-logs
+RUN chgrp -R 0 /jumphost-logs && chmod -R g=u /jumphost-logs
 
+EXPOSE 8080
 USER 1000
 
-CMD [ "npm", "run", "prod" ]
+CMD ["sh", "-c", "npm run prod | tee /jumphost-logs/jumphost.log"]
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "dotenv": "^16.0.3",
         "simple-git": "^3.16.0",
-        "winston": "^3.8.2"
+        "winston": "^3.8.2",
+        "winston-daily-rotate-file": "^4.7.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -129,6 +130,14 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "dependencies": {
+        "moment": "^2.29.1"
+      }
+    },
     "node_modules/fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -172,10 +181,26 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/one-time": {
       "version": "1.0.0",
@@ -299,6 +324,23 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz",
+      "integrity": "sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^2.0.1",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
+      }
+    },
     "node_modules/winston-transport": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
@@ -417,6 +459,14 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
+    "file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "requires": {
+        "moment": "^2.29.1"
+      }
+    },
     "fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -454,10 +504,20 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "one-time": {
       "version": "1.0.0",
@@ -549,6 +609,17 @@
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.5.0"
+      }
+    },
+    "winston-daily-rotate-file": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz",
+      "integrity": "sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==",
+      "requires": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^2.0.1",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
       }
     },
     "winston-transport": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "simple-git": "^3.16.0",
-    "winston": "^3.8.2"
+    "winston": "^3.8.2",
+    "winston-daily-rotate-file": "^4.7.1"
   }
 }

--- a/src/config/app.config.js
+++ b/src/config/app.config.js
@@ -1,2 +1,4 @@
 module.exports.PORT = process.env.PORT ? parseInt(process.env.PORT) : 8080;
 module.exports.ENVIRONMENT = process.env.ENVIRONMENT || "DEV";
+module.exports.LOGS_DIRECTORY =
+  process.env.LOGS_DIRECTORY || path.join(__dirname, "../../logs");

--- a/src/utils/logger.util.js
+++ b/src/utils/logger.util.js
@@ -8,7 +8,7 @@ const logConfiguration = {
     new winston.transports.Console(),
     new DailyRotateFile({
       filename: appConfig.LOGS_DIRECTORY + "/jumphost-%DATE%.log",
-      datePattern: "DD-MM-YY-HH",
+      datePattern: "DD-MM-YYYY",
     }),
   ],
   format: winston.format.combine(

--- a/src/utils/logger.util.js
+++ b/src/utils/logger.util.js
@@ -17,7 +17,7 @@ const logConfiguration = {
       const { message, timestamp, level } = info;
 
       let transformedMessage = message.replace(/\n/g, " ").trim();
-zz
+
       if (info instanceof Error) {
         transformedMessage = `${info.message} ${info.stack}`;
       }

--- a/src/utils/logger.util.js
+++ b/src/utils/logger.util.js
@@ -1,22 +1,30 @@
 const winston = require("winston");
 const appConfig = require("../config/app.config");
+const DailyRotateFile = require("winston-daily-rotate-file");
 
-const logger = winston.createLogger({
+const logConfiguration = {
   level: appConfig.ENVIRONMENT === "DEV" ? "debug" : "info",
+  transports: [
+    new winston.transports.Console(),
+    new DailyRotateFile({
+      filename: appConfig.LOGS_DIRECTORY + "/jumphost-%DATE%.log",
+      datePattern: "DD-MM-YY-HH",
+    }),
+  ],
   format: winston.format.combine(
-    winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
+    winston.format.timestamp({ format: "DD-MM-YYYY HH:mm:ss" }),
     winston.format.printf((info) => {
       const { message, timestamp, level } = info;
 
       let transformedMessage = message.replace(/\n/g, " ").trim();
-
+zz
       if (info instanceof Error) {
         transformedMessage = `${info.message} ${info.stack}`;
       }
       return `[${timestamp}] ${level}: ${transformedMessage}`;
     })
   ),
-  transports: [new winston.transports.Console()],
-});
+};
+const logger = winston.createLogger(logConfiguration);
 
 module.exports.logger = logger;


### PR DESCRIPTION
- Install winston-daily-rotate-file package to rotate logs on a daily basis
- Update Winston configuration to include DailyRotateFile transport for daily log rotation
- Log files are now created with a date pattern (e.g. jumphost-15-02-2023.log) and are rotated daily
- This improves log file organization and makes it easier to manage logs over time